### PR TITLE
Fix cookbook bind mounts spec for instance types without ephemeral_de…

### DIFF
--- a/opsworks_initial_setup/specs/bind_mounts_spec.rb
+++ b/opsworks_initial_setup/specs/bind_mounts_spec.rb
@@ -32,7 +32,7 @@ describe_recipe 'opsworks_initial_setup::bind_mounts' do
       httpd_logs_path = '/var/log/apache2'
     end
 
-    ephemeral_device = OpsWorks::ShellOut.shellout("df #{ephemeral_mount_point} | grep ^/").split.first
+    ephemeral_device = OpsWorks::ShellOut.shellout("readlink -f \"$(findmnt -n -o SOURCE \"$(stat -c%m #{ephemeral_mount_point})\")\"").split.first
 
     ["/var/log/mysql", "/srv/www", "/var/www", httpd_logs_path].each do |bind_mount_dir|
       OpsWorks::ShellOut.shellout("findmnt -c #{bind_mount_dir}").must_match %r{^#{bind_mount_dir}\s#{ephemeral_device}}


### PR DESCRIPTION
…vice

If the ephemeral_mount_point is not a separate device ubuntu 14.04 will
return:

$ df /mnt
Filesystem                                             1K-blocks    Used Available Use% Mounted on
/dev/disk/by-uuid/45a25334-26a8-41f4-97bd-ee71af165ff2   8115168 1549104 6130788  21% /

But expected is the short path of the device: /dev/xvda1
The commit now resolves the symlink of /dev/disk/by-uuid/45a25334-26a8-41f4-97bd-ee71af165ff2
